### PR TITLE
Added second argument to histograms.sh to specify output dir

### DIFF
--- a/_episodes/09-containerized-analysis.md
+++ b/_episodes/09-containerized-analysis.md
@@ -106,7 +106,7 @@ Now that we've preserved our full analysis environment in docker images, let's t
 > > 
 > > # Run the skimming code
 > > bash skim_prebuilt.sh root://eospublic.cern.ch//eos/root-eos/HiggsTauTauReduced/ /skimming_output
-> > bash histograms.sh /skimming_output
+> > bash histograms.sh /skimming_output /skimming_output
 > > ~~~
 > > {: .source}
 > > 


### PR DESCRIPTION
This PR updates the histograms.sh command to specify both input and output dirs:

bash histograms.sh /skimming_output /skimming_output

to match the format used in the example analysis intro tutorial (see eg. the first bash shell in [lesson 2](https://hsf-training.github.io/hsf-training-cms-analysis-webpage/04-histograms/index.html)). This is in conjunction with [this PR](https://github.com/hsf-training/hsf-training-cms-analysis-snapshot/pull/1)