### PR TITLE
Move `--docker-login` from end of `singularity shell` command to before image name

### DIFF
--- a/_episodes/10-singularity.md
+++ b/_episodes/10-singularity.md
@@ -99,7 +99,7 @@ export SINGULARITY_DOCKER_PASSWORD='mysecretpass'
 > > ## Solution
 > > ~~~bash
 > > export SINGULARITY_CACHEDIR="/tmp/$(whoami)/singularity"
-> > singularity shell -B /afs -B /eos -B /cvmfs docker://gitlab-registry.cern.ch/[repo owner's username]/[skimming repo name]:[branch name]-[shortened commit SHA] --docker-login
+> > singularity shell -B /afs -B /eos -B /cvmfs --docker-login docker://gitlab-registry.cern.ch/[repo owner's username]/[skimming repo name]:[branch name]-[shortened commit SHA]
 > > ~~~
 > > {: .source}
 > {: .solution}


### PR DESCRIPTION
It was found by Yury Smirnov that if the environment variables `SINGULARITY_DOCKER_USERNAME`, `SINGULARITY_DOCKER_PASSWORD` aren't pre-set, the `--docker-login` only works in the `singularity shell` command if put in front of the image name, not after.

