### PR TITLE
add glossary

### DIFF
--- a/reference.md
+++ b/reference.md
@@ -4,6 +4,32 @@ layout: reference
 
 ## Glossary
 
-FIXME
+To pull a docker container:
+
+```bash
+docker pull <image>
+```
+where ```<image>``` is the name of the docker container.
+
+To print a list of docker containers on your device:
+
+```bash
+docker images
+```
+
+To run a docker container the basic command is:
+
+```bash
+docker run <image>
+```
+For more options to run a docker container see [Episode 3](https://hsf-training.github.io/hsf-training-docker/03-running-containers/index.html)
+
+To exit a docker image (type the following within the container bash):
+
+```bash
+exit
+```
+
+
 
 {% include links.md %}


### PR DESCRIPTION
Closes #25 

Includes only the major steps required to install a docker image, run it and exit from the image: 
