### PR TITLE
build docker image using kanito

### DIFF
--- a/_episodes/08-gitlab-ci.md
+++ b/_episodes/08-gitlab-ci.md
@@ -114,13 +114,25 @@ Add the following lines at the end of the `.gitlab-ci.yml` file to build the ima
 
 ~~~yaml
 build_image:
+  image:
+    name: gitlab-registry.cern.ch/ci-tools/docker-image-builder
+    entrypoint: [""]
   stage: build
   variables:
-    TO: $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG-$CI_COMMIT_SHORT_SHA
-  tags:
-    - docker-image-build
+    GIT_SUBMODULE_STRATEGY: recursive
+    GIT_SSL_NO_VERIFY: "true"
   script:
-    - ignore
+    - echo "{\"auths\":{\"$CI_REGISTRY\":{\"username\":\"$CI_REGISTRY_USER\",\"password\":\"$CI_REGISTRY_PASSWORD\"}}}" > /kaniko/.docker/config.json
+    - '[[ $CI_COMMIT_REF_SLUG = "master" ]] && DOCKER_TAG="latest" || DOCKER_TAG="$CI_COMMIT_REF_SLUG"'
+    - /kaniko/executor --context $CI_PROJECT_DIR
+                       --dockerfile $CI_PROJECT_DIR/Dockerfile
+                       --destination $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG
+                       --destination $CI_REGISTRY_IMAGE:$DOCKER_TAG
+                       --build-arg CI_COMMIT_SHA=$CI_COMMIT_SHA
+                       --build-arg CI_COMMIT_REF_SLUG=$CI_COMMIT_REF_SLUG
+                       --build-arg CI_COMMIT_TAG=$CI_COMMIT_TAG
+                       --build-arg CI_JOB_URL=$CI_JOB_URL
+                       --build-arg CI_PROJECT_URL=$CI_PROJECT_URL
 ~~~
 {: .source}
 
@@ -138,10 +150,10 @@ You can also go to the container registry on the gitlab UI to see all the images
 
 <img src="../fig/ContainerRegistry.png" alt="ContainerRegistry" style="width:900px">
 
-Notice that the script to run is just a dummy 'ignore' command. This is because using the docker-image-build tag, the jobs always land on special runners that are managed by CERN IT which run a custom script in the background. You can safely ignore the details.
+<!--Notice that the script to run is just a dummy 'ignore' command. This is because using the docker-image-build tag, the jobs always land on special runners that are managed by CERN IT which run a custom script in the background. You can safely ignore the details.-->
 
 > ## Recommended Tag Structure
-> You'll notice the environment variable `TO` in the `.gitlab-ci.yml` script above. This controls the name of the Docker image that is produced in the CI step. Here, the image name will be `<reponame>:<branch or tagname>-<short commit SHA>`. The shortened 8-character commit SHA ensures that each image created from a different commit will be unique, and you can easily go back and find images from previous commits for debugging, etc.
+> You'll notice the argument `--destination` in the `.gitlab-ci.yml` script above. This controls the name of the Docker image that is produced in the CI step. Here, the image name will be `<reponame>:<branch or tagname>-<short commit SHA>`. The shortened 8-character commit SHA ensures that each image created from a different commit will be unique, and you can easily go back and find images from previous commits for debugging, etc.
 >
 > As you'll see tomorrow, it's recommended when using your images as part of a REANA workflow to make a unique image for each gitlab commit, because REANA will only attempt to update an image that it's already pulled if it sees that there's a new tag associated with the image.
 >

--- a/_episodes/09-containerized-analysis.md
+++ b/_episodes/09-containerized-analysis.md
@@ -51,12 +51,26 @@ To bring it all together, we can also preserve our fitting framework in its own 
 > >
 > > build_image:
 > >   stage: build
+> >   image:
+> >     name: gitlab-registry.cern.ch/ci-tools/docker-image-builder
+> >     entrypoint: [""]
+> >   stage: build
 > >   variables:
-> >     TO: $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG-$CI_COMMIT_SHORT_SHA
-> >   tags:
-> >     - docker-image-build
+> >     GIT_SUBMODULE_STRATEGY: recursive
+> >     GIT_SSL_NO_VERIFY: "true"
 > >   script:
-> >     - ignore
+> >     - echo "{\"auths\":{\"$CI_REGISTRY\":{\"username\":\"$CI_REGISTRY_USER\",\"password\":\"$CI_REGISTRY_PASSWORD\"}}}" > /kaniko/.docker/config.json
+> >     - '[[ $CI_COMMIT_REF_SLUG = "master" ]] && DOCKER_TAG="latest" || DOCKER_TAG="$CI_COMMIT_REF_SLUG"'
+> >     - /kaniko/executor --context $CI_PROJECT_DIR
+> >                        --dockerfile $CI_PROJECT_DIR/Dockerfile
+> >                        --destination $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG
+> >                        --destination $CI_REGISTRY_IMAGE:$DOCKER_TAG
+> >                        --build-arg CI_COMMIT_SHA=$CI_COMMIT_SHA
+> >                        --build-arg CI_COMMIT_REF_SLUG=$CI_COMMIT_REF_SLUG
+> >                        --build-arg CI_COMMIT_TAG=$CI_COMMIT_TAG
+> >                        --build-arg CI_JOB_URL=$CI_JOB_URL
+> >                        --build-arg CI_PROJECT_URL=$CI_PROJECT_URL
+> >
 > >
 > > [... rest of .gitlab-ci.yml]
 > > ~~~


### PR DESCRIPTION
<details>
<summary><strong>Update</strong></summary>

Remove `docker-image-build` because is deprecated for CERN GitLab
Replace it with kaniko

</details>
