### PR TITLE
Analysis Preservation Bootcamp 2023 @ Valencia

### DIFF
--- a/_episodes/01-introduction.md
+++ b/_episodes/01-introduction.md
@@ -43,8 +43,7 @@ very lightweight and fast to spin up to run.
 >
 > Singularity in particular is used widely in HPC, and particularly by CMS, so you may have need to familiarize yourself with it at some point.
 >
-> The [RECAST FAQ](https://recast-docs.web.cern.ch/recast-docs/faq/#q-how-are-docker-and-singularity-different) includes a brief intro to the important differences between docker and singularity.
-> To learn more about singularity, see for example the [HSF Training Singularity Module](https://github.com/hsf-training/hsf-training-singularity-webpage).
+> To learn more about singularity, see for example the [HSF Training Singularity Module](https://hsf-training.github.io/hsf-training-singularity-webpage/).
 {: .callout}
 
 [docker-tutorial]: https://docs.docker.com/get-started

--- a/_episodes/02-pulling-images.md
+++ b/_episodes/02-pulling-images.md
@@ -20,12 +20,9 @@ keypoints:
 
 Much like how GitHub allows for web hosting and searching for code, the [Docker Hub][docker-hub]
 image registry allows the same for Docker images.
-Hosting and building of images is [free for public repositories][docker-hub-billing] and
+Hosting images is [free for public repositories][docker-hub-billing] and
 allows for downloading images as they are needed.
-Additionally, through integrations with GitHub and Bitbucket, Docker Hub repositories can
-be linked against Git repositories so that
-[automated builds of Dockerfiles on Docker Hub][docker-hub-builds] will be triggered by
-pushes to repositories.
+Additionally, you can configure your GitLab or GitHub CI pipelines to automatically build and push docker images to Docker Hub.
 
 # Pulling Images
 
@@ -123,7 +120,7 @@ debian              buster              00bf7fdd8baf        5 weeks ago         
 {: .challenge}
 
 [docker-hub]: https://hub.docker.com/
-[docker-hub-billing]: https://hub.docker.com/billing-plans/
+[docker-hub-billing]: https://www.docker.com/pricing/
 [docker-hub-builds]: https://docs.docker.com/docker-hub/builds/
 [docker-docs-pull]: https://docs.docker.com/engine/reference/commandline/pull/
 [docker-docs-images]: https://docs.docker.com/engine/reference/commandline/images/

--- a/_episodes/03-running-containers.md
+++ b/_episodes/03-running-containers.md
@@ -65,10 +65,11 @@ cat /etc/os-release
 {: .source}
 
 ~~~
-PRETTY_NAME="Debian GNU/Linux 9 (stretch)"
+PRETTY_NAME="Debian GNU/Linux 11 (bullseye)"
 NAME="Debian GNU/Linux"
-VERSION_ID="9"
-VERSION="9 (stretch)"
+VERSION_ID="11"
+VERSION="11 (bullseye)"
+VERSION_CODENAME=bullseye
 ID=debian
 HOME_URL="https://www.debian.org/"
 SUPPORT_URL="https://www.debian.org/support"

--- a/_episodes/04-file-io.md
+++ b/_episodes/04-file-io.md
@@ -124,7 +124,13 @@ ls *.txt
 {: .source}
 
 >## Permission issues
->If you run into a `Permission denied` error, you can use ``sudo`` for a quick fix, if you have superuser access (but this is not recommended).
+>If you are using Linux with SELinux enabled, you might run into a `Permission denied` error.
+>Note that SELinux is enabled if the output of the command `getenforce status` is `Enforcing`.
+>To fix the permission issue, append `:z` (lowercase!) at the end of the mount option, like this:
+>```bash
+>docker run --rm -it -v $PWD:/home/docker/data:z ...
+>```
+>If this still does not fix the issue you can disable SELinux by running `sudo setenforce 0`, or you can try using `sudo` to execute docker commands, but both of these methods are not recommended.
 {: .callout}
 
 ~~~

--- a/_episodes/05-dockerfiles.md
+++ b/_episodes/05-dockerfiles.md
@@ -21,7 +21,7 @@ Docker images are built through the Docker engine by reading the instructions fr
 These text based documents provide the instructions through an API similar to the Linux
 operating system commands to execute commands during the build.
 The [`Dockerfile` for the example image][example-Dockerfile] being used is an example of
-some simple extensions of the [official Python 3.6.8 Docker image][python-docker-image].
+some simple extensions of the [official Python 3.9 Docker image][python-docker-image] based on Debian Bullseye (`python:3.9-bullseye`).
 
 As a very simple example of extending the example image into a new image create a `Dockerfile`
 on your local machine
@@ -113,8 +113,8 @@ python3 -c "import sklearn as sk; print(sk)"
                 ||----w |
                 ||     ||
 
-scikit-learn       0.21.3
-<module 'sklearn' from '/usr/local/lib/python3.6/site-packages/sklearn/__init__.py'>
+scikit-learn        1.3.1
+<module 'sklearn' from '/usr/local/lib/python3.9/site-packages/sklearn/__init__.py'>
 ~~~
 {: .output}
 
@@ -241,9 +241,9 @@ way to bring them into the Docker build.
 
 
 [docker-docs-builder]: https://docs.docker.com/engine/reference/builder/
-[example-Dockerfile]: https://github.com/matthewfeickert/Intro-to-Docker/blob/master/Dockerfile
+[example-Dockerfile]: https://github.com/matthewfeickert/intro-to-docker/blob/feat/update-2021-bootcamp/docker/Dockerfile
 [python-docker-image]: https://hub.docker.com/_/python
-[cowsay]: https://packages.debian.org/jessie/cowsay
+[cowsay]: https://packages.debian.org/bullseye/cowsay
 [scikit-learn]: https://scikit-learn.org
 [docker-docs-build]: https://docs.docker.com/engine/reference/commandline/build/
 [docker-docs-ARG]: https://docs.docker.com/engine/reference/builder/#arg

--- a/_episodes/08-gitlab-ci.md
+++ b/_episodes/08-gitlab-ci.md
@@ -64,6 +64,7 @@ As we've seen, all these components can be encoded in a Dockerfile. So the first
 > ~~~
 > {: .source}
 >
+> Hint: have a look at `skim.sh` if you are unsure about how to complete the last `RUN` statement!
 > > ## Solution
 > > ~~~yaml
 > > # Start from the rootproject/root base image with conda

--- a/_episodes/08-gitlab-ci.md
+++ b/_episodes/08-gitlab-ci.md
@@ -31,8 +31,8 @@ The goal of automated environment preservation is to create a docker image that 
 As we've seen, all these components can be encoded in a Dockerfile. So the first step to set up automated image building is to add a Dockerfile to the repo specifying these components.
 
 > ## The `rootproject/root` docker image
-> In this tutorial, we build our analysis environments on top of the `rootproject/root` base image ([link to project area on docker hub](https://hub.docker.com/r/rootproject/root)) with conda. This image comes with root 6.22 and python 3.7 pre-installed. It also comes with XrootD for downloading files from eos.
-> The `rootproject/root` is itself built with a [Dockerfile](https://github.com/root-project/root-docker/blob/6.22.06-conda/conda/Dockerfile), which uses conda to install root and python on top of another base image (`continuumio/miniconda3`).
+> In this tutorial, we build our analysis environments on top of the `rootproject/root` base image ([link to project area on docker hub](https://hub.docker.com/r/rootproject/root)) with conda. This image comes with root 6.22 and python 3.8 pre-installed. It also comes with XrootD for downloading files from eos.
+> The `rootproject/root` is itself built with a [Dockerfile](https://github.com/root-project/root-docker/blob/6.22.06-conda/conda/Dockerfile), which uses conda to install root and python on top of another base image (`condaforge/miniforge3`).
 {: .callout}
 
 > ## Exercise (15 min)

--- a/_episodes/08-gitlab-ci.md
+++ b/_episodes/08-gitlab-ci.md
@@ -107,7 +107,9 @@ As we've seen, all these components can be encoded in a Dockerfile. So the first
 Now, you can proceed with updating your `.gitlab-ci.yml` to actually build the container during the CI/CD pipeline and store it in the gitlab registry. You can later pull it from the gitlab registry just as you would any other container, but in this case using your CERN credentials.
 
 > ## Not from CERN?
-> If you do not have a CERN computing account with access to [gitlab.cern.ch](https://[gitlab.cern.ch), then everything discussed here is also available on [gitlab.com](https://gitlab.com) offers CI/CD tools, including the docker builder. Furthermore, you can do the same with github + dockerhub as explained in the next subsection.
+> If you do not have a CERN computing account with access to [gitlab.cern.ch](https://[gitlab.cern.ch), then everything discussed here is also available on [gitlab.com](https://gitlab.com), which offers CI/CD tools, including the docker builder.
+> Furthermore, you can achieve the same with GitHub + Github Container Registry.
+> To learn more about these methods, see the next subsections.
 {: .callout}
 
 Add the following lines at the end of the `.gitlab-ci.yml` file to build the image and save it to the docker registry.
@@ -176,42 +178,10 @@ In the `script` of this job there are three components :
 
 If the job runs successfully, then in the same way as described for [gitlab.cern.ch](https://[gitlab.cern.ch) in the previous section, you will be able to find the `Container Registry` on the left hand icon menu of your gitlab.com web browser and navigate to the image that was pushed to the registry.  Et voila, c'est fini, exactement comme au CERN!
 
-### Alternative: Automatic image building with github + dockerhub
+### Alternative: GitHub.com
 
-If you don't have access to [gitlab.cern.ch](https://gitlab.cern.ch), you can still
-automatically build a docker image every time you push to a repository with github and
-dockerhub.
-
-1. Create a clone of the skim and the fitting repository on your private github.
-  You can use the
-  [GitHub Importer](https://docs.github.com/en/github/importing-your-projects-to-github/importing-a-repository-with-github-importer)
-  for this. It's up to you whether you want to make this repository public or private.
-
-2. Create a free account on [dockerhub](http://hub.docker.com/).
-3. Once you confirmed your email, head to ``Settings`` > ``Linked Accounts``
-   and connect your github account.
-4. Go back to the home screen (click the dockerhub icon top left) and click ``Create Repository``.
-5. Choose a name of your liking, then click on the  github icon in the ``Build settings``.
-   Select your account name as organization and select your repository.
-6. Click on the ``+`` next to ``Build rules``. The default one does fine
-7. Click ``Create & Build``.
-
-That's it! Back on the home screen your repository should appear. Click on it and select the
-``Builds`` tab to watch your image getting build (it probably will take a couple of minutes
-before this starts). If something goes wrong check the logs.
-
-<img src="../fig/dockerhub_build.png" alt="DockerHub" style="width:900px">
-
-Once the build is completed, you can pull your image in the usual way.
-
-~~~bash
-# If you made your docker repository private, you first need to login,
-# else you can skip the following line
-docker login
-# Now pull
-docker pull <username>/<image name>:<tag>
-~~~
-{: .source}
+You can also build Docker images on [github.com](https://github.com) and push them to the GitHub Container Registry ([ghcr.io](https://ghcr.io)) with the help of [GitHub Actions](https://github.com/features/actions).
+The bonus episode [Building and deploying a Docker container to Github Packages](/hsf-training-docker/12-bonus/index.html) explains how to do so.
 
 ## An updated version of `skim.sh`
 

--- a/_episodes/09-containerized-analysis.md
+++ b/_episodes/09-containerized-analysis.md
@@ -95,12 +95,12 @@ Now that we've preserved our full analysis environment in docker images, let's t
 > mkdir fitting_output
 > ~~~
 >
-> Find a partner and pull the image they've built for their skimming repo from the gitlab registry. Launch a container using your partner's image. Try to run the analysis code to produce the `histogram.root` file that will get input to the fitting repo, using the `skim_prebuilt.sh` script we created in the previous lesson for the first skimming step. You can follow the skimming instructions in [step 1](https://gitlab.cern.ch/awesome-workshop/awesome-analysis-eventselection-stage2/blob/master/README.md#step-1-skimming) and [step 2](https://gitlab.cern.ch/awesome-workshop/awesome-analysis-eventselection-stage2/blob/master/README.md#step-2-histograms) of the README.
+> Find a partner and pull the image they've built for their skimming repo from the gitlab registry. Launch a container using your partner's image. Try to run the analysis code to produce the `histogram.root` file that will get input to the fitting repo, using the `skim_prebuilt.sh` script we created in the previous lesson for the first skimming step. You can follow the skimming instructions in [step 1](https://github.com/hsf-training/hsf-training-cms-analysis-snapshot#step-1-skimming) and [step 2](https://github.com/hsf-training/hsf-training-cms-analysis-snapshot#step-2-histograms) of the README.
 >
 > **Note:** We'll need to pass the output from the skimming stage to the fitting stage. To enable this, you can volume mount the `skimming_output` directory into the container. Then, as long as you save the skimming output to the volume-mounted location in the container, it will also be available locally under `skimming_output`.
 >
 > ### Part 2: Fitting
-> Now, pull your partner's fitting image and use it to produce the final fit result. Remember to volume-mount the `skimming_output` and `fitting_output` so the container has access to both. At the end, the `fitting_output` directory on your local machine should contain the final fit results. You can follow the instructions in [step 4](https://gitlab.cern.ch/awesome-workshop/awesome-analysis-eventselection-stage2/blob/master/README.md#step-4-fit) of the README.
+> Now, pull your partner's fitting image and use it to produce the final fit result. Remember to volume-mount the `skimming_output` and `fitting_output` so the container has access to both. At the end, the `fitting_output` directory on your local machine should contain the final fit results. You can follow the instructions in [step 4](https://github.com/hsf-training/hsf-training-cms-analysis-snapshot#step-4-fit) of the README.
 >
 > > ## Solution
 > > ### Part 1:  Skimming

--- a/_episodes/09-containerized-analysis.md
+++ b/_episodes/09-containerized-analysis.md
@@ -52,11 +52,18 @@ To bring it all together, we can also preserve our fitting framework in its own 
 > > build_image:
 > >   stage: build
 > >   variables:
-> >     TO: $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG-$CI_COMMIT_SHORT_SHA
-> >   tags:
-> >     - docker-image-build
+> >     IMAGE_DESTINATION: $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG-$CI_COMMIT_SHORT_SHA
+> >   image:
+> >     # The kaniko debug image is recommended because it has a shell, and a shell is required for an image to be used with GitLab CI/CD.
+> >     name: gcr.io/kaniko-project/executor:debug
+> >     entrypoint: [""]
 > >   script:
-> >     - ignore
+> >     # Prepare Kaniko configuration file
+> >     - echo "{\"auths\":{\"$CI_REGISTRY\":{\"username\":\"$CI_REGISTRY_USER\",\"password\":\"$CI_REGISTRY_PASSWORD\"}}}" > /kaniko/.docker/config.json
+> >     # Build and push the image from the Dockerfile at the root of the project.
+> >     - /kaniko/executor --context $CI_PROJECT_DIR --dockerfile $CI_PROJECT_DIR/Dockerfile --destination $IMAGE_DESTINATION
+> >     # Print the full registry path of the pushed image
+> >     - echo "Image pushed successfully to ${IMAGE_DESTINATION}"
 > >
 > > [... rest of .gitlab-ci.yml]
 > > ~~~

--- a/_episodes/11-entry.md
+++ b/_episodes/11-entry.md
@@ -30,7 +30,7 @@ docker run --rm -it python:3.7-slim /bin/bash
 Running this dumps us into a Bash session
 
 ~~~bash
-printenv | grep SHELL
+echo $SHELL
 ~~~
 {: .source}
 

--- a/_episodes/12-bonus.md
+++ b/_episodes/12-bonus.md
@@ -8,8 +8,8 @@ questions:
 objectives:
 - To be able to build a Docker container and share it via GitHub packages
 keypoints:
--  Python packages can be installed in Docker images along with ubuntu packages.
--  It is possible to publish and share Docker images over github packages.
+- Python packages can be installed in Docker images along with ubuntu packages.
+- It is possible to publish and share Docker images over github packages.
 ---
 
 > ## Prerequisites
@@ -22,7 +22,7 @@ keypoints:
 
 Python packages can be installed using a Docker image. The following example illustrates how to write a Dockerfile for building an image containing python packages.
 
-```text
+```docker
 FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -60,13 +60,15 @@ To do so, one needs to use GitHub CI/CD. A step-by-step guide is presented here.
 * **Step 4**: Copy-paste the content above and add it to the Dockerfile. (In principle it is possible to build this image locally, but we will not do that here, as we wish to build it with GitHub CI/CD).
 * **Step 5**: In the `Docker-build-deploy.yml` file, add the following content:
 
-```text
+{% raw %}
+```yaml
 name: Create and publish a Docker image
 
 on:
-  pull_request:
   push:
-    branches: master
+    branches:
+      - main
+      - master
 
 env:
   REGISTRY: ghcr.io
@@ -75,16 +77,17 @@ env:
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
+
     permissions:
       contents: read
       packages: write
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -92,18 +95,20 @@ jobs:
 
       - name: Docker Metadata
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 ```
+{% endraw %}
+
 
 The above script is designed to build and publish a Docker image with [GitHub packages](https://github.com/features/packages).
 

--- a/setup.md
+++ b/setup.md
@@ -49,10 +49,14 @@ A few things to keep in mind if starting from these 'starter repos':
 * Regarding authentication with ``kinit``:
   * If you are from CERN and use gitlab.cern.ch: Remember to add your CERN credentials as CI/CD variables to
     both repos for the `kinit` authentication in the `.gitlab-ci.yml` files to work.
-    To do so, go to _Settings_ -> _CI/CD_ -> _Variables_ and create two new variables: `CERN_USER` should contain your CERN username, and `SERVICE_PASS` should contain your password.
-  * Else, you can remove the ``kinit`` line from `.gitlab-ci.yml` and use the public EOS dataset available at `root://eospublic.cern.ch//eos/root-eos/HiggsTauTauReduced`.
-* For the fitting code repo, the [fit_simple](https://github.com/hsf-training/hsf-training-cms-analysis-snapshot-stats/blob/master/.gitlab-ci.yml#L5) step in `.gitlab-ci.yml` expects to receive the file `histograms.root` produced by the skimming code. In case you haven't had a chance to produce this file yet, it can be downloaded from [here](https://cernbox.cern.ch/index.php/s/LADW94G9fjY7hjF).
-  * If you are from CERN, you'll need to copy this file to your personal eos user space (`root://eosuser.cern.ch//eos/user/[first_letter_of_username]/[username]`)
-  * else: use the public eos link.
+    To do so, go to _Settings_ -> _CI/CD_ -> _Variables_ and create two new variables:
+     * `CERN_USER` should contain your CERN username
+     * `SERVICE_PASS` should contain your password.
+  * Else, you can remove the ``kinit`` line from `.gitlab-ci.yml` and use the public EOS datasets:
+    * `root://eospublic.cern.ch//eos/root-eos/HiggsTauTauReduced` for the skimming repo.
+    * `root://eospublic.cern.ch//eos/opendata/cms/upload/apb2023/histograms.root` for the fitting repo.
+* For the fitting code repo, the [fit_simple](https://github.com/hsf-training/hsf-training-cms-analysis-snapshot-stats/blob/master/.gitlab-ci.yml#L5) step in `.gitlab-ci.yml` expects to receive the file `histograms.root` produced by the skimming code. In case you haven't had a chance to produce this file yet, it can be downloaded from [here](https://eospublichttp.cern.ch//eos/opendata/cms/upload/apb2023/histograms.root). In any case you can:
+  * use the public EOS datasets mentioned above.
+  * If you are from CERN, you can copy the downloaded file to your personal eos user space (`root://eosuser.cern.ch//eos/user/[first_letter_of_username]/[username]`).
 
 {% include links.md %}


### PR DESCRIPTION
This PR includes the changes made to this lesson for the Analysis Preservation Bootcamp 2023 @ Valencia ([indico event](https://indico.ific.uv.es/event/6964/))

Commits:
- **Remove references to DockerHub automated builds**
  Automated DockerHub builds are now a paid feature, so the lesson does not explain them anymore

- **Update description of docker images**
  Updated the description of the docker images used and the output of commands such as `cat /etc/os-release`

- **Add note about SELinux**

- **Use Kaniko to build docker images on CERN GitLab**
  The `docker-image-build` tag is not supported at CERN anymore, Kaniko is used instead to build docker images

- **Improve bonus episode on GitHub packages**
  Fix the rendering of the YAML config file, as `{{ ... }}` were considered as part of the template and would be hidden.

  Build and publish the docker image only on push and not for each pull request.

  Update the GitHub actions to the latest versions.

- **Fix broken links**

- **Add hint on how to find compilation command**

- **Fix command to show current shell**
  Previous command was not working anymore

- **Update links to fitting dataset**
  Note that one of the links here was created specifically for apb23, so that should probably be stored longterm somewhere else