### PR TITLE
Podman commands in chapters 2 to 6

### DIFF
--- a/_episodes/02-pulling-images.md
+++ b/_episodes/02-pulling-images.md
@@ -26,7 +26,8 @@ allows for downloading images as they are needed.
 Additionally, through integrations with GitHub and Bitbucket, Docker Hub repositories can
 be linked against Git repositories so that
 [automated builds of Dockerfiles on Docker Hub][docker-hub-builds] will be triggered by
-pushes to repositories. However, at this moment enabling such a feature requires a Pro (paid) account.
+pushes to repositories. However, at this moment enabling such a feature requires a Pro (paid) account
+or joining the [Docker-Sponsored Open Source Program](https://www.docker.com/community/open-source/application/).
 There are other ways of doing this, such as using GitLab/GitHub CI/CD, but that's beyond the scope of this training module.
 
 > ## Docker Hub and Podman
@@ -40,7 +41,7 @@ There are other ways of doing this, such as using GitLab/GitHub CI/CD, but that'
 # Pulling Images
 
 To begin with we're going to [pull][podman-docs-pull] down the image we're going
-to be working in for the tutorial (note: if you did all the docker pulls in the setup instructions, this image will already be on your machine, in which case docker should notice it's there and not attempt to re-pull it unless it's changed in the meantime):
+to be working in for the tutorial (note: if you did all the docker pulls in the setup instructions, this image will already be on your machine, in which case podman should notice it's there and not attempt to re-pull it unless it's changed in the meantime):
 
 ~~~bash
 podman pull matthewfeickert/intro-to-docker

--- a/_episodes/02-pulling-images.md
+++ b/_episodes/02-pulling-images.md
@@ -10,8 +10,8 @@ objectives:
 - "List local images"
 - "Introduce image tags"
 keypoints:
-- "Pull images with `docker pull <image-id>`"
-- "List all images on the computer and other information with `docker images`"
+- "Pull images with `podman pull <image-id>`"
+- "List all images on the computer and other information with `podman images`"
 - "Image tags distinguish releases or version and are appended to the image name with a colon"
 ---
 <iframe width="427" height="251" src="https://www.youtube.com/embed/JihkukeoNVs?list=PLKZ9c4ONm-VnqD5oN2_8tXO0Yb1H_s0sj" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
@@ -22,30 +22,42 @@ Much like how GitHub allows for web hosting and searching for code, the [Docker 
 image registry allows the same for Docker images.
 Hosting and building of images is [free for public repositories][docker-hub-billing] and
 allows for downloading images as they are needed.
+
 Additionally, through integrations with GitHub and Bitbucket, Docker Hub repositories can
 be linked against Git repositories so that
 [automated builds of Dockerfiles on Docker Hub][docker-hub-builds] will be triggered by
-pushes to repositories.
+pushes to repositories. However, at this moment enabling such a feature requires a Pro (paid) account.
+There are other ways of doing this, such as using GitLab/GitHub CI/CD, but that's beyond the scope of this training module.
+
+> ## Docker Hub and Podman
+>
+> Both Docker and Podman use OCI (Open Container Initiative) compliant images, so you can use the same images with both tools.
+> It means Podman can pull and run images from Docker Hub.
+>
+> By default, Podman pull pulls an image from Docker Hub if a registry is not specified in the command line argument.
+{: .callout}
 
 # Pulling Images
 
-To begin with we're going to [pull][docker-docs-pull] down the Docker image we're going
+To begin with we're going to [pull][podman-docs-pull] down the image we're going
 to be working in for the tutorial (note: if you did all the docker pulls in the setup instructions, this image will already be on your machine, in which case docker should notice it's there and not attempt to re-pull it unless it's changed in the meantime):
 
 ~~~bash
-docker pull matthewfeickert/intro-to-docker
+podman pull matthewfeickert/intro-to-docker
 ~~~
 {: .source}
 
-> ## Permission errors
-> If you run into a permission error, use `sudo docker run ...` as a quick fix.
-> To fix this for the future (**recommended**), see [the docker docs](https://docs.docker.com/install/linux/linux-postinstall/).
+> ## Connection errors
+> If using Podman or Docker in a non-Linux machine you run into an error like `Error: unable to connect to Podman`,
+> make sure that the Podman or Docker desktop application is running.
+>
+> Remember that in such environments, Podman or Docker use a virtual machine to run the containers.
 {: .callout}
 
-and then [list the images][docker-docs-images] that we have available to us locally
+and then [list the images][podman-docs-images] that we have available to us locally
 
 ~~~bash
-docker images
+podman images
 ~~~
 {: .source}
 
@@ -53,7 +65,7 @@ If you have many images and want to get information on a particular one you can 
 filter, such as the repository name
 
 ~~~bash
-docker images matthewfeickert/intro-to-docker
+podman images matthewfeickert/intro-to-docker
 ~~~
 {: .source}
 
@@ -66,7 +78,7 @@ matthewfeickert/intro-to-docker   latest              cf6508749ee0        3 mont
 or more explicitly
 
 ~~~bash
-docker images --filter=reference="matthewfeickert/intro-to-docker"
+podman images --filter=reference="matthewfeickert/intro-to-docker"
 ~~~
 {: .source}
 
@@ -80,11 +92,11 @@ You can see here that there is the `TAG` field associated with the
 `matthewfeickert/intro-to-docker` image.
 Tags are a way of further specifying different versions of the same image.
 As an example, let's pull the buster release tag of the
-[Debian image](https://hub.docker.com/_/debian) (again, if it was already pulled during setup, docker won't attempt to re-pull it unless it's changed since last pulled).
+[Debian image](https://hub.docker.com/_/debian) (again, if it was already pulled during setup, podman won't attempt to re-pull it unless it's changed since last pulled).
 
 ~~~bash
-docker pull debian:buster
-docker images debian
+podman pull debian:buster
+podman images debian
 ~~~
 {: .source}
 
@@ -100,23 +112,23 @@ debian              buster              00bf7fdd8baf        5 weeks ago         
 ~~~
 {: .output}
 
+Check the documentation on [pull][podman-docs-pull] and [images][podman-docs-images] for more information on these commands.
+
 > ## Pulling Python
 >
-> Pull the image python3.7-slim for Python 3.7 and then list all `python` images along with
-> the `matthewfeickert/intro-to-docker` image
+> Pull the image python3.7-slim for Python 3.7 and then list all `python` images on your computer.
 >
 > > ## Solution
 > >
 > > ~~~bash
-> > docker pull python:3.7-slim
-> > docker images --filter=reference="matthewfeickert/intro-to-docker" --filter=reference="python"
+> > podman pull python:3.7-slim
+> > podman images --filter=reference="python"
 > > ~~~
 > > {: .source}
 > >
 > > ~~~
 > > REPOSITORY                        TAG                 IMAGE ID            CREATED             SIZE
 > > python                            3.7                 e440e2151380        23 hours ago        918MB
-> > matthewfeickert/intro-to-docker   latest              cf6508749ee0        3 months ago        1.49GB
 > > ~~~
 > > {: .output}
 > {: .solution}
@@ -125,7 +137,7 @@ debian              buster              00bf7fdd8baf        5 weeks ago         
 [docker-hub]: https://hub.docker.com/
 [docker-hub-billing]: https://hub.docker.com/billing-plans/
 [docker-hub-builds]: https://docs.docker.com/docker-hub/builds/
-[docker-docs-pull]: https://docs.docker.com/engine/reference/commandline/pull/
-[docker-docs-images]: https://docs.docker.com/engine/reference/commandline/images/
+[podman-docs-pull]: https://docs.podman.io/en/latest/markdown/podman-pull.1.html
+[podman-docs-images]: https://docs.podman.io/en/stable/markdown/podman-images.1.html
 
 {% include links.md %}

--- a/_episodes/02-pulling-images.md
+++ b/_episodes/02-pulling-images.md
@@ -35,7 +35,7 @@ There are other ways of doing this, such as using GitLab/GitHub CI/CD, but that'
 > Both Docker and Podman use OCI (Open Container Initiative) compliant images, so you can use the same images with both tools.
 > It means Podman can pull and run images from Docker Hub.
 >
-> By default, Podman pull pulls an image from Docker Hub if a registry is not specified in the command line argument.
+> By default, `podman pull` pulls an image from Docker Hub if a registry is not specified in the command line argument.
 {: .callout}
 
 # Pulling Images
@@ -117,26 +117,33 @@ Check the documentation on [pull][podman-docs-pull] and [images][podman-docs-ima
 
 > ## Pulling Python
 >
-> Pull the image python3.7-slim for Python 3.7 and then list all `python` images on your computer.
+> Pull the image python:3.9-slim for Python 3.9 and then list all `python` images on your computer.
+>
+> See [the Python Official Images][docker-hub-python] to find the available tags and
+> read about the image variants. What `'slim'` means?
 >
 > > ## Solution
 > >
 > > ~~~bash
-> > podman pull python:3.7-slim
+> > podman pull python:3.9-slim
 > > podman images --filter=reference="python"
 > > ~~~
 > > {: .source}
 > >
 > > ~~~
 > > REPOSITORY                        TAG                 IMAGE ID            CREATED             SIZE
-> > python                            3.7                 e440e2151380        23 hours ago        918MB
+> > docker.io/library/python          3.9-slim            e440e2151380        2 weeks ago        131 MB
 > > ~~~
+> >
+> >* `python:<version>-slim`: This image does not contain the common packages contained in the default
+> >tag and only contains the minimal packages needed to run python
 > > {: .output}
 > {: .solution}
 {: .challenge}
 
 [docker-hub]: https://hub.docker.com/
 [docker-hub-billing]: https://www.docker.com/pricing/
+[docker-hub-python]: https://hub.docker.com/_/python
 [docker-hub-builds]: https://docs.docker.com/docker-hub/builds/
 [podman-docs-pull]: https://docs.podman.io/en/latest/markdown/podman-pull.1.html
 [podman-docs-images]: https://docs.podman.io/en/stable/markdown/podman-images.1.html

--- a/_episodes/02-pulling-images.md
+++ b/_episodes/02-pulling-images.md
@@ -119,8 +119,8 @@ Check the documentation on [pull][podman-docs-pull] and [images][podman-docs-ima
 >
 > Pull the image python:3.9-slim for Python 3.9 and then list all `python` images on your computer.
 >
-> See [the Python Official Images][docker-hub-python] to find the available tags and
-> read about the image variants. What `'slim'` means?
+> Browse [the official Python images][docker-hub-python] to find available tags and
+> read about image variants. What does `-slim` mean?
 >
 > > ## Solution
 > >

--- a/_episodes/03-running-containers.md
+++ b/_episodes/03-running-containers.md
@@ -19,7 +19,7 @@ keypoints:
 ---
 <iframe width="427" height="251" src="https://www.youtube.com/embed/UejGBfppmZY?list=PLKZ9c4ONm-VnqD5oN2_8tXO0Yb1H_s0sj" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-To use a image as a particular instance on a host machine you [run][podman-docks-run]
+To use an image as a particular instance on a host machine, you [run][podman-docs-run]
 it as a container.
 You can run in either a detached or foreground (interactive) mode.
 

--- a/_episodes/03-running-containers.md
+++ b/_episodes/03-running-containers.md
@@ -83,14 +83,14 @@ BUG_REPORT_URL="https://bugs.debian.org/"
 >This is the working directory that was set for the image.
 >
 > In the next chapters we will see how to build your own images
-> and set parameters as the working directory.
+> and set parameters such as the working directory.
 >{: .source}
 {: .callout}
 
 ## Monitoring Containers
 
 Open up a new terminal tab on the host machine and
-[list the containers that are currently running][podman-docks-ps]
+[list the containers that are currently running][podman-docs-ps]
 
 ~~~bash
 podman ps
@@ -104,7 +104,7 @@ CONTAINER ID        IMAGE         COMMAND             CREATED             STATUS
 {: .output}
 
 Notice that the name of your container is some randomly generated name.
-To make the name more helpful, [rename][podman-docks-rename] the running container
+To make the name more helpful, [rename][podman-docs-rename] the running container
 
 ~~~bash
 podman rename <CONTAINER ID> my-example
@@ -186,8 +186,8 @@ CONTAINER ID        IMAGE         COMMAND             CREATED            STATUS 
 ~~~
 {: .output}
 
-To restart your exited container [start][podman-docks-start] it again and then
-[attach][podman-docks-attach] it interactively to your shell
+To restart your exited container [start][podman-docs-start] it again and then
+[attach][podman-docs-attach] it interactively to your shell
 
 ~~~bash
 podman start <CONTAINER ID>
@@ -196,9 +196,9 @@ podman attach <CONTAINER ID>
 {: .source}
 
 > ## `exec` command
-> The [attach][podman-docks-attach] command used here is a handy shortcut to interactively access a running container with the same start command (in this case `/bin/bash`) that it was originally run with.
+> The [attach][podman-docs-attach] command used here is a handy shortcut to interactively access a running container with the same start command (in this case `/bin/bash`) that it was originally run with.
 >
-> In case you'd like some more flexibility, the [exec][podman-docks-exec] command lets you run any command in the container, with options similar to the run command to enable an interactive (`-i`) session, etc.
+> In case you'd like some more flexibility, the [exec][podman-docs-exec] command lets you run any command in the container, with options similar to the run command to enable an interactive (`-i`) session, etc.
 >
 > For example, the `exec` equivalent to `attach`ing in our case would look like:
 > ~~~bash
@@ -237,7 +237,7 @@ return to our working environment inside of them as desired.
 
 >## Clean up a container
 >
->If you want a container to be [cleaned up][podman-docks-run-clean-up] &mdash; that is
+>If you want a container to be [cleaned up][podman-docs-run-clean-up] &mdash; that is,
 >deleted &mdash; after you exit it then run with the `--rm` option flag
 >
 >~~~bash
@@ -246,12 +246,13 @@ return to our working environment inside of them as desired.
 >{: .source}
 {: .callout}
 
-[podman-docks-run]: https://docs.podman.io/en/stable/markdown/podman-run.1.html
+[podman-docs-run]: https://docs.podman.io/en/stable/markdown/podman-run.1.html
 [docker-hub-python]: https://github.com/docker-library/python
-[podman-docks-ps]: https://docs.podman.io/en/stable/markdown/podman-ps.1.html
-[podman-docks-rename]: https://docs.docker.com/engine/reference/commandline/rename/
-[podman-docks-start]: https://docs.docker.com/engine/reference/commandline/start/
-[podman-docks-attach]: https://docs.docker.com/engine/reference/commandline/attach/
-[podman-docks-exec]: https://docs.docker.com/engine/reference/commandline/exec/
+[podman-docs-ps]: https://docs.podman.io/en/stable/markdown/podman-ps.1.html
+[podman-docs-rename]: https://docs.docker.com/engine/reference/commandline/rename/
+[podman-docs-start]: https://docs.docker.com/engine/reference/commandline/start/
+[podman-docs-attach]: https://docs.docker.com/engine/reference/commandline/attach/
+[podman-docs-exec]: https://docs.docker.com/engine/reference/commandline/exec/
+[podman-docs-run-clean-up]: https://docs.podman.io/en/stable/markdown/podman-run.1.html#rm
 
 {% include links.md %}

--- a/_episodes/03-running-containers.md
+++ b/_episodes/03-running-containers.md
@@ -90,7 +90,7 @@ BUG_REPORT_URL="https://bugs.debian.org/"
 ## Monitoring Containers
 
 Open up a new terminal tab on the host machine and
-[list the containers that are currently running][podman-docs-ps]
+[list the containers that are currently running][podman-docs-ps]:
 
 ~~~bash
 podman ps

--- a/_episodes/03-running-containers.md
+++ b/_episodes/03-running-containers.md
@@ -77,6 +77,16 @@ BUG_REPORT_URL="https://bugs.debian.org/"
 ~~~
 {: .output}
 
+> ## Working directory
+>
+>You may be wondering why you are at `/home/docker/data` inside the container.
+>This is the working directory that was set for the image.
+>
+> In the next chapters we will see how to build your own images
+> and set parameters as the working directory.
+>{: .source}
+{: .callout}
+
 ## Monitoring Containers
 
 Open up a new terminal tab on the host machine and

--- a/_episodes/03-running-containers.md
+++ b/_episodes/03-running-containers.md
@@ -12,21 +12,21 @@ objectives:
 - "Understand container state"
 - "Stop and restart containers"
 keypoints:
-- "Run containers with `docker run <image-id>`"
-- "Monitor containers with `docker ps`"
+- "Run containers with `podman run <image-id>`"
+- "Monitor containers with `podman ps`"
 - "Exit interactive sessions using the `exit` command"
-- "Restart stopped containers with `docker start`"
+- "Restart stopped containers with `podman start`"
 ---
 <iframe width="427" height="251" src="https://www.youtube.com/embed/UejGBfppmZY?list=PLKZ9c4ONm-VnqD5oN2_8tXO0Yb1H_s0sj" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-To use a Docker image as a particular instance on a host machine you [run][docker-docs-run]
+To use a image as a particular instance on a host machine you [run][podman-docks-run]
 it as a container.
-You can run in either a [detached or foreground][docker-docs-run-detached] (interactive) mode.
+You can run in either a [detached or foreground][podman-docks-run-detached] (interactive) mode.
 
 Run the image we pulled as a container with an interactive bash terminal:
 
 ~~~bash
-docker run -it matthewfeickert/intro-to-docker:latest /bin/bash
+podman run -it matthewfeickert/intro-to-docker:latest /bin/bash
 ~~~
 {: .source}
 
@@ -65,10 +65,11 @@ cat /etc/os-release
 {: .source}
 
 ~~~
-PRETTY_NAME="Debian GNU/Linux 9 (stretch)"
+PRETTY_NAME="Debian GNU/Linux 11 (bullseye)"
 NAME="Debian GNU/Linux"
-VERSION_ID="9"
-VERSION="9 (stretch)"
+VERSION_ID="11"
+VERSION="11 (bullseye)"
+VERSION_CODENAME=bullseye
 ID=debian
 HOME_URL="https://www.debian.org/"
 SUPPORT_URL="https://www.debian.org/support"
@@ -79,10 +80,10 @@ BUG_REPORT_URL="https://bugs.debian.org/"
 ## Monitoring Containers
 
 Open up a new terminal tab on the host machine and
-[list the containers that are currently running][docker-docs-ps]
+[list the containers that are currently running][podman-docks-ps]
 
 ~~~bash
-docker ps
+podman ps
 ~~~
 {: .source}
 
@@ -93,17 +94,17 @@ CONTAINER ID        IMAGE         COMMAND             CREATED             STATUS
 {: .output}
 
 Notice that the name of your container is some randomly generated name.
-To make the name more helpful, [rename][docker-docs-rename] the running container
+To make the name more helpful, [rename][podman-docks-rename] the running container
 
 ~~~bash
-docker rename <CONTAINER ID> my-example
+podman rename <CONTAINER ID> my-example
 ~~~
 {: .source}
 
 and then verify it has been renamed
 
 ~~~bash
-docker ps
+podman ps
 ~~~
 {: .source}
 
@@ -118,7 +119,7 @@ CONTAINER ID        IMAGE         COMMAND             CREATED             STATUS
 >You can also identify containers to rename by their current name
 >
 >~~~bash
->docker rename <NAME> my-example
+>podman rename <NAME> my-example
 >~~~
 >{: .source}
 {: .callout}
@@ -126,7 +127,7 @@ CONTAINER ID        IMAGE         COMMAND             CREATED             STATUS
 Alternatively, you can also give the container a name at creation, using the `--name ` option:
 
 ~~~bash
-docker run -it --name my-fancy-name matthewfeickert/intro-to-docker:latest /bin/bash
+podman run -it --name my-fancy-name matthewfeickert/intro-to-docker:latest /bin/bash
 ~~~
 {: .source}
 
@@ -153,7 +154,7 @@ You are returned to your shell.
 If you list the containers you will notice that none are running
 
 ~~~bash
-docker ps
+podman ps
 ~~~
 {: .source}
 
@@ -165,7 +166,7 @@ CONTAINER ID        IMAGE               COMMAND             CREATED             
 but you can see all containers that have been run and not removed with
 
 ~~~bash
-docker ps -a
+podman ps -a
 ~~~
 {: .source}
 
@@ -175,24 +176,24 @@ CONTAINER ID        IMAGE         COMMAND             CREATED            STATUS 
 ~~~
 {: .output}
 
-To restart your exited Docker container [start][docker-docs-start] it again and then
-[attach][docker-docs-attach] it interactively to your shell
+To restart your exited container [start][podman-docks-start] it again and then
+[attach][podman-docks-attach] it interactively to your shell
 
 ~~~bash
-docker start <CONTAINER ID>
-docker attach <CONTAINER ID>
+podman start <CONTAINER ID>
+podman attach <CONTAINER ID>
 ~~~
 {: .source}
 
 > ## `exec` command
-> The [attach][docker-docs-attach] command used here is a handy shortcut to interactively access a running container with the same start command (in this case `/bin/bash`) that it was originally run with.
+> The [attach][podman-docks-attach] command used here is a handy shortcut to interactively access a running container with the same start command (in this case `/bin/bash`) that it was originally run with.
 >
-> In case you'd like some more flexibility, the [exec][docker-docs-exec] command lets you run any command in the container, with options similar to the run command to enable an interactive (`-i`) session, etc.
+> In case you'd like some more flexibility, the [exec][podman-docks-exec] command lets you run any command in the container, with options similar to the run command to enable an interactive (`-i`) session, etc.
 >
 > For example, the `exec` equivalent to `attach`ing in our case would look like:
 > ~~~bash
-> docker start <CONTAINER ID>
-> docker exec -it <CONTAINER ID> /bin/bash
+> podman start <CONTAINER ID>
+> podman exec -it <CONTAINER ID> /bin/bash
 > ~~~
 {: .callout}
 
@@ -201,8 +202,8 @@ docker attach <CONTAINER ID>
 >You can also start and attach containers by their name
 >
 >~~~bash
->docker start <NAME>
->docker attach <NAME>
+>podman start <NAME>
+>podman attach <NAME>
 >~~~
 >{: .source}
 {: .callout}
@@ -221,28 +222,26 @@ test.txt
 ~~~
 {: .output}
 
-So this shows us that we can exit Docker containers for arbitrary lengths of time and then
+So this shows us that we can exit containers for arbitrary lengths of time and then
 return to our working environment inside of them as desired.
 
 >## Clean up a container
 >
->If you want a container to be [cleaned up][docker-docs-run-clean-up] &mdash; that is
+>If you want a container to be [cleaned up][podman-docks-run-clean-up] &mdash; that is
 >deleted &mdash; after you exit it then run with the `--rm` option flag
 >
 >~~~bash
->docker run --rm -it <IMAGE> /bin/bash
+>podman run --rm -it <IMAGE> /bin/bash
 >~~~
 >{: .source}
 {: .callout}
 
-[docker-docs-run]: https://docs.docker.com/engine/reference/run/
-[docker-docs-run-detached]: https://docs.docker.com/engine/reference/run/#detached-vs-foreground
-[docker-docs-run-clean-up]: https://docs.docker.com/engine/reference/run/#clean-up---rm
+[podman-docks-run]: https://docs.podman.io/en/stable/markdown/podman-run.1.html
 [docker-hub-python]: https://github.com/docker-library/python
-[docker-docs-ps]: https://docs.docker.com/engine/reference/commandline/ps/
-[docker-docs-rename]: https://docs.docker.com/engine/reference/commandline/rename/
-[docker-docs-start]: https://docs.docker.com/engine/reference/commandline/start/
-[docker-docs-attach]: https://docs.docker.com/engine/reference/commandline/attach/
-[docker-docs-exec]: https://docs.docker.com/engine/reference/commandline/exec/
+[podman-docks-ps]: https://docs.podman.io/en/stable/markdown/podman-ps.1.html
+[podman-docks-rename]: https://docs.docker.com/engine/reference/commandline/rename/
+[podman-docks-start]: https://docs.docker.com/engine/reference/commandline/start/
+[podman-docks-attach]: https://docs.docker.com/engine/reference/commandline/attach/
+[podman-docks-exec]: https://docs.docker.com/engine/reference/commandline/exec/
 
 {% include links.md %}

--- a/_episodes/03-running-containers.md
+++ b/_episodes/03-running-containers.md
@@ -21,7 +21,7 @@ keypoints:
 
 To use a image as a particular instance on a host machine you [run][podman-docks-run]
 it as a container.
-You can run in either a [detached or foreground][podman-docks-run-detached] (interactive) mode.
+You can run in either a detached or foreground (interactive) mode.
 
 Run the image we pulled as a container with an interactive bash terminal:
 

--- a/_episodes/04-file-io.md
+++ b/_episodes/04-file-io.md
@@ -32,7 +32,7 @@ and then from the container check and modify it in some way
 pwd
 ls
 cat io_example.txt
-echo "This was written inside the Container" >> io_example.txt
+echo "This was written inside the container" >> io_example.txt
 ~~~
 {: .source}
 
@@ -69,7 +69,7 @@ cat io_example.txt
 
 ~~~
 This was written on local host
-This was written inside the Container
+This was written inside the container
 ~~~
 {: .output}
 

--- a/_episodes/04-file-io.md
+++ b/_episodes/04-file-io.md
@@ -151,7 +151,7 @@ ls *.txt
 >```bash
 >podman run --rm -it -v $PWD:/home/docker/data:z ...
 >```
->If this still does not fix the issue you can disable SELinux by running `sudo setenforce 0`, or you can try using `sudo` to execute docker/podman commands, but both of these methods are not recommended.
+>If this still does not fix the issue you can disable SELinux by running `sudo setenforce 0`, or you can try using `sudo` to execute docker/podman commands, but neither of these methods is recommended.
 {: .callout}
 
 ~~~

--- a/_episodes/04-file-io.md
+++ b/_episodes/04-file-io.md
@@ -43,7 +43,7 @@ echo "This was written inside the Container" >> io_example.txt
 >chmod a+w io_example.txt  # add write permissions for all users
 >~~~
 >{: .source}
->And continue from the ``docker cp ...`` command above.
+>And continue from the ``podman cp ...`` command above.
 {: .callout}
 
 ~~~

--- a/_episodes/04-file-io.md
+++ b/_episodes/04-file-io.md
@@ -8,22 +8,21 @@ objectives:
 - "Copy files to and from the docker container"
 - "Mount directories to be accessed and manipulated by the docker container"
 keypoints:
-- "Copy files with `docker cp`"
-- "Mount volumes with `docker run -v <path on host>:<path in container> <image>`"
+- "Copy files with `podman cp`"
+- "Mount volumes with `podman run -v <path on host>:<path in container> <image>`"
 ---
 <iframe width="427" height="251" src="https://www.youtube.com/embed/t93igGemQi8?list=PLKZ9c4ONm-VnqD5oN2_8tXO0Yb1H_s0sj" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 # Copying
 
-[Copying][docker-docs-cp] files between the local host and Docker containers is possible.
+[Copying][podman-docs-cp] files between the local host and containers is possible.
 On your local host, either find a file that you want to transfer to the container or create a new one. Below is the procedure
 for creating a new file called io_example.txt and then copying it to the container:
 
 ~~~bash
 touch io_example.txt
-# If on Mac need to do: chmod a+w io_example.txt
 echo "This was written on local host" > io_example.txt
-docker cp io_example.txt <NAME>:/home/docker/data/
+podman cp io_example.txt <NAME>:/home/docker/data/
 ~~~
 {: .source}
 
@@ -33,12 +32,12 @@ and then from the container check and modify it in some way
 pwd
 ls
 cat io_example.txt
-echo "This was written inside Docker" >> io_example.txt
+echo "This was written inside the Container" >> io_example.txt
 ~~~
 {: .source}
 
 >## Permission issues
->If you run into a `Permission denied` error, there is a simple and quick fix:
+>If you run into a `Permission denied` error, there is a simple and quick fix to continue with the exercise:
 >~~~bash
 >exit  # exit container
 >chmod a+w io_example.txt  # add write permissions for all users
@@ -57,7 +56,7 @@ This was written on local host
 and then on the local host copy the file out of the container
 
 ~~~bash
-docker cp <NAME>:/home/docker/data/io_example.txt .
+podman cp <NAME>:/home/docker/data/io_example.txt .
 ~~~
 {: .source}
 
@@ -70,19 +69,19 @@ cat io_example.txt
 
 ~~~
 This was written on local host
-This was written inside Docker
+This was written inside the Container
 ~~~
 {: .output}
 
 # Volume mounting
 
-What is more common and arguably more useful is to [mount volumes][docker-docs-volumes] to
+What is more common and arguably more useful is to [mount volumes][podman-docs-volumes] to
 containers with the `-v` flag.
-This allows for direct access to the host file system inside of the container and for
+This allows for direct access to the host file system inside the container and for
 container processes to write directly to the host file system.
 
 ~~~bash
-docker run -v <path on host>:<path in container> <image>
+podman run -v <path on host>:<path in container> <image>
 ~~~
 {: .source}
 
@@ -90,9 +89,31 @@ For example, to mount your current working directory (``$PWD``) on your local ma
 directory in the example container
 
 ~~~bash
-docker run --rm -it -v $PWD:/home/docker/data matthewfeickert/intro-to-docker
+podman run --rm -it -v $PWD:/home/docker/data matthewfeickert/intro-to-docker
 ~~~
 {: .source}
+
+> ## No such file or directory?
+> On Windows and macOS, you may face an error while mounting the volume:
+> `Error: statfs <directory>: no such file or directory`.
+>
+> The error occurs because the directory you are trying to mount was not shared with the virtual machine
+> that runs the containers. In latest versions of Podman and Docker your home directory is shared by
+> default, but with Podman you can restart the machine to ensure that the directory is mounted:
+>
+> ```bash
+> podman machine stop
+> podman machine start
+> ```
+> ~~~
+> Starting machine "podman-machine-default"
+> Waiting for VM ...
+> Mounting volume... /Users:/Users
+> ...
+> Machine "podman-machine-default" started successfully
+> ~~~
+> {: .output}
+{: .callout}
 
 From inside the container you can `ls` to see the contents of your directory on your local
 machine
@@ -128,9 +149,9 @@ ls *.txt
 >Note that SELinux is enabled if the output of the command `getenforce status` is `Enforcing`.
 >To fix the permission issue, append `:z` (lowercase!) at the end of the mount option, like this:
 >```bash
->docker run --rm -it -v $PWD:/home/docker/data:z ...
+>podman run --rm -it -v $PWD:/home/docker/data:z ...
 >```
->If this still does not fix the issue you can disable SELinux by running `sudo setenforce 0`, or you can try using `sudo` to execute docker commands, but both of these methods are not recommended.
+>If this still does not fix the issue you can disable SELinux by running `sudo setenforce 0`, or you can try using `sudo` to execute docker/podman commands, but both of these methods are not recommended.
 {: .callout}
 
 ~~~
@@ -138,7 +159,7 @@ created_inside.txt
 ~~~
 {: .output}
 
-This I/O allows for Docker images to be used for specific tasks that may be difficult to
+This I/O allows for container images to be used for specific tasks that may be difficult to
 do with the tools or software installed on only the local host machine.
 For example, debugging problems with software that arise on cross-platform software, or
 even just having a specific version of software perform a task (e.g., using Python 2 when
@@ -181,8 +202,8 @@ even just having a specific version of software perform a task (e.g., using Pyth
 <!---->
 <!--You now have access to Jupyter running on your Docker container.-->
 <!---->
-[docker-docs-cp]: https://docs.docker.com/engine/reference/commandline/cp/
-[docker-docs-volumes]: https://docs.docker.com/storage/volumes/
+[podman-docs-cp]: https://docs.podman.io/en/latest/markdown/podman-cp.1.html
+[podman-docs-volumes]: https://docs.podman.io/en/v4.4/markdown/podman-run.1.html#volume-v-source-volume-host-dir-container-dir-options
 [Tex-Live-image]: https://hub.docker.com/r/matthewfeickert/latex-docker/
 [docker-docs-run-expose-ports]: https://docs.docker.com/engine/reference/run/#expose-incoming-ports
 [jupyter-docs-server]: https://jupyter.readthedocs.io/en/latest/running.html#starting-the-notebook-server

--- a/_episodes/05-dockerfiles.md
+++ b/_episodes/05-dockerfiles.md
@@ -16,16 +16,17 @@ keypoints:
 ---
 <iframe width="427" height="251" src="https://www.youtube.com/embed/8BhkS2rZQ6E?list=PLKZ9c4ONm-VnqD5oN2_8tXO0Yb1H_s0sj" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-Container images are the static files that contain the instructions to build create containers on machines.
-Container engines pull the images from repositories or local storage and then create containers from them.
+Container images are static files that contain a template to create containers on machines.
+Container engines like Podman or Docker pull the images from repositories or local storage and then create containers from them.
+Container engines can also build and save to a repository new container images, interactively or following a set of instructions, starting from scratch or modifying an existing image.
 
-A common way of defining the instructions to build a container image is through a [`Dockerfile`][docker-docs-builder].
+A common way of defining the instructions to build a container image is through a [Dockerfile][docker-docs-builder].
 These text based documents provide the instructions through an API similar to the Linux
 operating system commands to execute commands during the build.
 The [`Dockerfile` for the example image][example-Dockerfile] being used is an example of
 some simple extensions of the [official Python 3.9 Docker image][python-docker-image] based on Debian Bullseye (`python:3.9-bullseye`).
 
-Podman also uses `Dockerfile`s to build images, so the same instructions can be used for both tools.
+Like Docker, Podman also uses `Dockerfile`s to build images, so the same instructions can be used for both tools.
 We will continue with Podman throughout this lesson but the same commands can be used with Docker.
 
 As a very simple example of extending the example image into a new image create a `Dockerfile`
@@ -71,7 +72,8 @@ USER docker
 >Each `RUN` command in a Dockerfile creates a new layer to the image.
 >In general, each layer should try to do one job and the fewer layers in an image
 > the easier it is compress.
-> This is why you see all these '&& \'s in the `RUN` command, so that all the shell commands will take place in a single layer.
+>
+> This is why you see all these '&& \'s in the `RUN` command, so that all the shell commands will run in a pipeline and will take place in a single layer
 > When trying to upload and download images on demand the smaller the size the better.
 >
 > Another thing to keep in mind is that each `RUN` command occurs in its own shell, so any environment variables, etc. set in one `RUN` command will not persist to the next.

--- a/_episodes/05-dockerfiles.md
+++ b/_episodes/05-dockerfiles.md
@@ -103,7 +103,7 @@ You can now run the image as a container and verify for yourself that your addit
 ~~~bash
 podman run --rm -it extend-example:latest /bin/bash
 which cowsay
-cowsay "Hello from inside the Container"
+cowsay "Hello from inside the container"
 pip list | grep scikit
 python3 -c "import sklearn as sk; print(sk)"
 ~~~

--- a/_episodes/05-dockerfiles.md
+++ b/_episodes/05-dockerfiles.md
@@ -174,7 +174,7 @@ podman tag <SOURCE_IMAGE[:TAG]> <TARGET_IMAGE[:TAG]>
 > >REPOSITORY                TAG         IMAGE ID      CREATED      SIZE
 > >localhost/extend-example  my-tag      c24a757fabe7  9 hours ago  2.2 GB
 > >localhost/extend-example  latest      c24a757fabe7  9 hours ago  2.2 GB
-
+>>
 > > ~~~
 > > {: .output}
 > {: .solution}

--- a/_episodes/05-dockerfiles.md
+++ b/_episodes/05-dockerfiles.md
@@ -88,7 +88,7 @@ USER docker
 >greater privileges.
 {: .callout}
 
-Then [`build`][docker-docs-build] an image from the `Dockerfile` with Podman and tag it with a
+Then [`build`][podman-docs-build] an image from the `Dockerfile` with Podman and tag it with a
 human-readable name
 
 ~~~bash
@@ -268,11 +268,7 @@ way to bring them into the container image build.
 [python-docker-image]: https://hub.docker.com/_/python
 [cowsay]: https://packages.debian.org/bullseye/cowsay
 [scikit-learn]: https://scikit-learn.org
-[docker-docs-build]: https://docs.docker.com/engine/reference/commandline/build/
-[docker-docs-ARG]: https://docs.docker.com/engine/reference/builder/#arg
-[docker-docs-FROM]: https://docs.docker.com/engine/reference/builder/#from
-[docker-docs-build-arg]: https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg
-[docker-docs-ENV]: https://docs.docker.com/engine/reference/builder/#env
+[podman-docs-build]: https://docs.podman.io/en/stable/markdown/podman-build.1.html
 [podman-docs-tag]: https://docs.podman.io/en/latest/markdown/podman-tag.1.html
 [docker-docs-COPY]: https://docs.docker.com/engine/reference/builder/#copy
 

--- a/_episodes/05-dockerfiles.md
+++ b/_episodes/05-dockerfiles.md
@@ -10,7 +10,7 @@ objectives:
 - "Build a Docker image from a Dockerfile"
 keypoints:
 - "Dockerfiles are written as text file commands to the Docker engine"
-- "Docker images are built with `docker build`"
+- "Docker images are built with `podman build`"
 - "Docker images can have multiple tags associated to them"
 - "Docker images can use `COPY` to copy files into them during build"
 ---

--- a/_episodes/05-dockerfiles.md
+++ b/_episodes/05-dockerfiles.md
@@ -112,7 +112,7 @@ python3 -c "import sklearn as sk; print(sk)"
 ~~~
 /usr/bin/cowsay
  ___________________
-< Hello from inside the Container >
+< Hello from inside the container >
  -------------------
         \   ^__^
          \  (oo)\_______

--- a/_episodes/06-removal.md
+++ b/_episodes/06-removal.md
@@ -83,7 +83,7 @@ podman rmi <IMAGE ID>
 > >
 > >REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
 > >python              2.7-slim            d75b4eed9ada        14 hours ago        886MB
-> >python              3.7-slim            e440e2151380        23 hours ago        918MB
+> >python              3.9-slim            e440e2151380        23 hours ago        918MB
 > >
 > >Untagged: python@sha256:<the relevant SHA hash>
 > >Deleted: sha256:<layer SHA hash>
@@ -98,7 +98,7 @@ podman rmi <IMAGE ID>
 > >Deleted: sha256:<layer SHA hash>
 > >
 > >REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
-> >python              3.7-slim            e440e2151380        23 hours ago        918MB
+> >python              3.9-slim            e440e2151380        23 hours ago        918MB
 > > ~~~
 > > {: .output}
 > {: .solution}

--- a/_episodes/06-removal.md
+++ b/_episodes/06-removal.md
@@ -6,32 +6,32 @@ questions:
 - "How do you cleanup old containers?"
 - "How do you delete images?"
 objectives:
-- "Learn how to cleanup after Docker"
+- "Learn how to cleanup after working with containers"
 keypoints:
-- "Remove containers with `docker rm <CONTAINER NAME>`"
-- "Remove images with `docker rmi <IMAGE ID>`"
-- "Perform faster cleanup with `docker container prune`, `docker image prune`, and `docker system prune`"
+- "Remove containers with `podman rm <CONTAINER NAME>`"
+- "Remove images with `podman rmi <IMAGE ID>`"
+- "Perform faster cleanup with `podman container prune`, `podman image prune`, and `podman system prune`"
 ---
 <iframe width="427" height="251" src="https://www.youtube.com/embed/Gsp6EapBcoo?list=PLKZ9c4ONm-VnqD5oN2_8tXO0Yb1H_s0sj" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-You can cleanup/remove a container [`docker rm`][docker-docs-rm]
+You can cleanup/remove a container with [`podman rm`][podman-docs-rm]
 ~~~bash
-docker rm <CONTAINER NAME>
+podman rm <CONTAINER NAME>
 ~~~
 {: .source}
 
 > ## Remove old containers
 >
 > Start an instance of the tutorial container, exit it, and then remove it with
-> `docker rm`
+> `podman rm`
 >
 > > ## Solution
 > >
 > > ~~~bash
-> > docker run matthewfeickert/intro-to-docker:latest
-> > docker ps -a
-> > docker rm <CONTAINER NAME>
-> > docker ps -a
+> > podman run matthewfeickert/intro-to-docker:latest
+> > podman ps -a
+> > podman rm <CONTAINER NAME>
+> > podman ps -a
 > > ~~~
 > > {: .source}
 > >
@@ -47,9 +47,9 @@ docker rm <CONTAINER NAME>
 > {: .solution}
 {: .challenge}
 
-You can remove an image from your computer entirely with [`docker rmi`][docker-docs-rmi]
+You can remove an image from your computer entirely with [`podman rmi`][podman-docs-rmi]
 ~~~bash
-docker rmi <IMAGE ID>
+podman rmi <IMAGE ID>
 ~~~
 {: .source}
 
@@ -60,10 +60,10 @@ docker rmi <IMAGE ID>
 > > ## Solution
 > >
 > > ~~~bash
-> > docker pull python:2.7-slim
-> > docker images python
-> > docker rmi <IMAGE ID>
-> > docker images python
+> > podman pull python:2.7-slim
+> > podman images python
+> > podman rmi <IMAGE ID>
+> > podman images python
 > > ~~~
 > > {: .source}
 > >
@@ -105,14 +105,14 @@ docker rmi <IMAGE ID>
 {: .challenge}
 
 > ## Helpful cleanup commands
-> What is helpful is to have Docker detect and remove unwanted images and containers for you.
+> What is helpful is to have a command to detect and remove unwanted images and containers for you.
 > This can be done with `prune`, which depending on the context will remove different things.
-> - [`docker container prune`](https://docs.docker.com/engine/reference/commandline/container_prune/) removes all stopped containers, which is helpful to clean up forgotten stopped containers.
-> - [`docker image prune`](https://docs.docker.com/engine/reference/commandline/image_prune/) removes all unused or dangling images (images that do not have a tag). This is helpful for cleaning up after builds.
-> - [`docker system prune`](https://docs.docker.com/engine/reference/commandline/system_prune/) removes all stopped containers, dangling images, and dangling build caches. This is very helpful for cleaning up everything all at once.
+> - [`podman container prune`](https://docs.podman.io/en/latest/markdown/podman-container-prune.1.html) removes all stopped containers, which is helpful to clean up forgotten stopped containers.
+> - [`podman image prune`](https://docs.podman.io/en/latest/markdown/podman-image-prune.1.html) removes all unused or dangling images (images that do not have a tag). This is helpful for cleaning up after builds.
+> - [`podman system prune`](https://docs.podman.io/en/stable/markdown/podman-system-prune.1.html) removes all stopped containers, dangling images, and dangling build caches. This is very helpful for cleaning up everything all at once.
 {: .callout}
 
-[docker-docs-rm]: https://docs.docker.com/engine/reference/commandline/rm/
-[docker-docs-rmi]: https://docs.docker.com/engine/reference/commandline/rmi/
+[podman-docs-rm]: https://docs.podman.io/en/stable/markdown/podman-rm.1.html
+[podman-docs-rmi]: https://docs.podman.io/en/latest/markdown/podman-rmi.1.html
 
 {% include links.md %}


### PR DESCRIPTION
Following #81, I am putting Podman in front of Docker as an alternative to follow the tutorial. 

For now covering chapters 2 to 6, as the rest requires a discussion during the HSF meeting on how to proceed with automatic builds. 