### PR TITLE
docs: rename CITATION to CITATION.cff and update authors

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,1 +1,11 @@
-Matthew Feickert <matthew.feickert@cern.ch>
+Matthew Feickert
+Danika Eamer
+Max Fatouros
+Michel Hernández Villanueva
+Aman Desai
+Marco Donadoni
+Kilian Lieret
+Valeriia Lukashenko
+Marco Mambelli
+Samuel Meehan
+Brendan Regnery

--- a/CITATION
+++ b/CITATION
@@ -1,1 +1,0 @@
-FIXME: describe how to cite this lesson.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,60 @@
+cff-version: 1.2.0
+message: "If you use this lesson, please cite it as below."
+title: "Introduction to Docker and Podman"
+abstract: >-
+  An HSF Training lesson introducing Docker and Podman as software development
+  tools and exploring their role in reproducible research. Originally developed
+  by Matthew Feickert for the 2019 USATLAS Computing Bootcamp at LBNL.
+type: software
+license:
+  - CC-BY-4.0
+  - MIT
+repository-code: "https://github.com/hsf-training/hsf-training-docker"
+url: "https://hsf-training.github.io/hsf-training-docker/"
+version: "v2026.08.19"
+date-released: "2026-08-19"
+identifiers:
+  - type: doi
+    value: "10.5281/zenodo.22016838"
+    description: "Concept DOI resolving to the latest version of this lesson on Zenodo."
+keywords:
+  - training
+  - docker
+  - podman
+  - containers
+  - reproducibility
+  - high energy physics
+authors:
+  - family-names: Feickert
+    given-names: Matthew
+    orcid: "https://orcid.org/0000-0003-4124-7862"
+  - family-names: Eamer
+    given-names: Danika
+    orcid: "https://orcid.org/0000-0001-5533-6300"
+  - family-names: Fatouros
+    given-names: Max
+    orcid: "https://orcid.org/0000-0002-7438-652X"
+  - family-names: Hernández Villanueva
+    given-names: Michel
+    orcid: "https://orcid.org/0000-0002-6322-5587"
+  - family-names: Desai
+    given-names: Aman
+    orcid: "https://orcid.org/0000-0003-2631-9696"
+  - family-names: Donadoni
+    given-names: Marco
+    orcid: "https://orcid.org/0000-0003-2922-5505"
+  - family-names: Lieret
+    given-names: Kilian
+    orcid: "https://orcid.org/0000-0003-2792-7511"
+  - family-names: Lukashenko
+    given-names: Valeriia
+    orcid: "https://orcid.org/0000-0002-0630-5185"
+  - family-names: Mambelli
+    given-names: Marco
+    orcid: "https://orcid.org/0000-0002-9489-2681"
+  - family-names: Meehan
+    given-names: Samuel
+    orcid: "https://orcid.org/0000-0002-3613-7514"
+  - family-names: Regnery
+    given-names: Brendan
+    orcid: "https://orcid.org/0000-0003-1539-923X"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Introduction to Docker and Podman
 [![HSF Training Center](https://img.shields.io/badge/HSF%20Training%20Center-browse-ff69b4)](https://hepsoftwarefoundation.org/training/curriculum.html)
-[![Build Status](https://travis-ci.org/hsf-training/hsf-training-docker.svg?branch=gh-pages)](https://travis-ci.org/hsf-training/hsf-training-docker)
+[![pages-build-deployment](https://github.com/hsf-training/hsf-training-docker/actions/workflows/pages/pages-build-deployment/badge.svg)](https://github.com/hsf-training/hsf-training-docker/actions/workflows/pages/pages-build-deployment)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.22016838.svg)](https://doi.org/10.5281/zenodo.22016838)
 
 This repository generates the corresponding lesson website from [The Carpentries](https://carpentries.org/) repertoire of lessons.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ Look for the tag ![good_first_issue](https://img.shields.io/badge/-good%20first%
 Current maintainers of this lesson are
 
 * [Matthew Feickert](http://www.matthewfeickert.com/)
-* Danika MacDonell <danikam1@uvic.ca>
 
 ## Authors
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ This project follows the [all-contributors](https://github.com/all-contributors/
 
 ## Citation
 
-To cite this lesson, please consult with [CITATION](CITATION)
+To cite this lesson, please consult with [CITATION.cff](CITATION.cff), or use the "Cite this repository" button in the sidebar.
 
 ## Open Educational Resources (OER) on Zenodo
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

The `CITATION` file was still an unfilled `FIXME:` placeholder. This renames it to `CITATION.cff` — the exact name GitHub's "Cite this repository" widget and Zenodo's metadata extraction both key off — populates it, and syncs `AUTHORS` to match.

## How the author list was derived

Line counts on **lesson material only** (`_episodes/`, `_extras/`, `setup.md`, `index.md`, `reference.md`, `examples/`), cross-checked against `git blame` of the current files, with commit subjects read before deciding. Repo-wide statistics are dominated by the vendored Carpentries theme and point at the wrong people.

Two things the raw numbers got wrong:

- Feickert's 390-line *"Migrate to using SWC styling"* is a format sweep, not authorship. He is still far ahead on real material (398-line GitLab CI episode, 199 CMD/ENTRYPOINT, 117 removal episode).
- vlukashenko's 388-line top commit is a re-add of files deleted in a prior commit — the deprecation rename — not authorship. The real contribution is a 63-line podman/kaniko rework.

Principal authors first by contribution, then alphabetically by family name so that citation styles truncating to "et al." do not attribute the work to whoever happens to sort first:

| Author | Basis |
| --- | --- |
| Feickert | 1869 lines; wrote the original lesson |
| Eamer | 612; adapted it for the analysis preservation bootcamp |
| Fatouros | 497; setup rewrite and macOS podman VM |
| Hernández Villanueva | 476; the Docker → Podman migration |
| Desai, Donadoni, Lieret, Lukashenko, Mambelli, Meehan, Regnery | each authored a named section or episode |

All 11 authors carry a verified ORCID, so no `affiliation` fields are needed — affiliation is the one field that silently goes stale.

**Not listed:** copy-editing only (grammar and comma placement), sub-10-line contributions, bots, and the Carpentries template maintainers. The latter is the notable one — Michonneau, Wilson, Silva and Belkin have zero lines of lesson material here; their commits arrived through merges from `carpentries/styles` and `hsf-training/hsf-styles`, with subjects like `[fix carpentries/styles#477] rewrite travis script`. Every lesson pulling from the template inherits that history.

## Other changes

- **Concept DOI** `10.5281/zenodo.22016838` added — the lesson is already archived on Zenodo and the citation file was missing it.
- **`version` / `date-released`** set to the `v2026.08.19` release.
- **License corrected to a list.** `LICENSE.md` is dual: instructional material under CC BY 4.0, and a `### Software` section placing the Carpentries example programs under MIT.
- **`AUTHORS`** now lists the same people in the same order, and drops its single email address, which was already stale.
- **`README.md`** citation link retargeted.

Validated with `cffconvert --validate` against schema 1.2.0.

## Worth a maintainer decision before merging

**Zenodo creators will narrow.** The current record lists **28 creators**, auto-derived from GitHub profiles because no `CITATION.cff` existed — including the Carpentries template maintainers and raw handles like `bregnery` and `GabeSoto`. From the next release Zenodo reads this file instead, and that becomes 11. This is the intended correction, but it is a visible change to a published record.

**Three authors' material is now deprecated.** Meehan, Regnery and Lukashenko wrote the GitLab CI, Singularity and containerized-analysis episodes, which are dot-prefixed and no longer built — zero surviving lines in the active lesson. They are included here because each authored a whole section or episode, which is not what the exclusion criteria target, but a citation reflecting only the lesson as delivered would drop them.
